### PR TITLE
Flatten value in FTry bind

### DIFF
--- a/src/chippyash/Monad/FTry.php
+++ b/src/chippyash/Monad/FTry.php
@@ -37,8 +37,7 @@ abstract class FTry extends Monad
                     return new Failure($potentialException);
                 }
             } elseif ($value instanceof Monadic) {
-                //test to ensure enclosed Monad value isn't an exception
-                static::create($value->flatten());
+                return static::create($value->flatten());
             }
 
             return new Success($value);

--- a/test/src/chippyash/FTry/SuccessTest.php
+++ b/test/src/chippyash/FTry/SuccessTest.php
@@ -33,6 +33,16 @@ class SuccessTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Monad\FTry\Success', $sut->bind(function(){return true;}));
     }
 
+    public function testBindingASuccessWithSomethingThatReturnsASuccessWillFlattenTheValue()
+    {
+      $sut = new Success('foo');
+      $binded = $sut->bind(function () {
+        return new Success('bar');
+      });
+      $this->assertInstanceOf('Monad\FTry\Success', $binded);
+      $this->assertEquals('bar', $binded->value());
+    }
+
     public function testBindingASuccessWithSomethingThatThrowsAnExceptionWillReturnAFailure()
     {
         $sut = new Success('foo');


### PR DESCRIPTION
Flatten value in the `bind` method of `FTry`, so in case the binded function returns a `Success`, we do not end up with nested `Success`. So the `FTry::bind` method can act both as a `map` (it is already the case) and a `bind`.